### PR TITLE
Default CSS used

### DIFF
--- a/modules/theme_manager/code/controller.ext.php
+++ b/modules/theme_manager/code/controller.ext.php
@@ -33,6 +33,11 @@ class module_controller extends ctrl_module
     static function ExecuteUpdateTheme($uid, $theme)
     {
         global $zdbh;
+
+        /* Set CSS back to default */
+        self::ExecuteUpdateCSS($uid, 'default');
+
+        /* Set new theme */
         $sql = $zdbh->prepare("
             UPDATE x_accounts
             SET ac_usertheme_vc = :theme


### PR DESCRIPTION
Basically, if you choose a theme with a variation and then switch to a completly different theme it tries to use the same variation with that theme, even if it doesn't exist.

This PR always sets CSS to default when switching theme. Tested and working fine on my server.

As discussed at http://forums.sentora.io/showthread.php?tid=89
