### PR TITLE
Deny access to modules directly

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,5 +11,8 @@ RewriteRule ^apps/([^/\.]+)/?$ etc/apps/$1 [L]
 RewriteRule ^/?(\.git|\.tx|SQL|config|logs|temp|tests|program\/(include|lib|localization|steps)) - [F]
 RewriteRule ^(etc/tmp|etc/zppy-cache|/etc/lib/pChart2/cache|etc/build) - [F,L,NC]
 
+# Deny access to modules directly
+RewriteRule ^modules/.*\.(php|zpm|xml)$ - [F,L,NC]
+
 # Disable index listing
 Options -Indexes


### PR DESCRIPTION
There is no reason to access any module directly. So lock down. Any module should communicate thru the interfaces and framework.