### PR TITLE
Set ServerTokens to correct level

### DIFF
--- a/etc/build/config_packs/centos_6/apache/httpd.conf
+++ b/etc/build/config_packs/centos_6/apache/httpd.conf
@@ -26,7 +26,7 @@ Alias /zpanel /etc/zpanel/panel
 </Directory>
 
 # Set server tokens
-ServerTokens Prod
+ServerTokens OS
 
 # Now we include the generic VHOST configuration file that holds all the ZPanel user hosted vhost data
 Include /etc/zpanel/configs/apache/httpd-vhosts.conf

--- a/etc/build/config_packs/centos_6_2/apache/httpd.conf
+++ b/etc/build/config_packs/centos_6_2/apache/httpd.conf
@@ -24,8 +24,8 @@ Alias /zpanel /etc/zpanel/panel
     Deny from All
 </Directory>
 
-# Set server tokens (security??)
-ServerTokens Maj
+# Set server tokens
+ServerTokens OS
 
 # Now we include the generic VHOST configuration file that holds all the ZPanel user hosted vhost data
 Include /etc/zpanel/configs/apache/httpd-vhosts.conf

--- a/etc/build/config_packs/centos_6_3/apache/httpd.conf
+++ b/etc/build/config_packs/centos_6_3/apache/httpd.conf
@@ -25,8 +25,8 @@ Alias /zpanel /etc/zpanel/panel
     Deny from All
 </Directory>
 
-# Set server tokens (security??)
-ServerTokens Major
+# Set server tokens
+ServerTokens OS
 
 # Now we include the generic VHOST configuration file that holds all the ZPanel user hosted vhost data
 Include /etc/zpanel/configs/apache/httpd-vhosts.conf

--- a/etc/build/config_packs/ubuntu_12_04/apache/httpd.conf
+++ b/etc/build/config_packs/ubuntu_12_04/apache/httpd.conf
@@ -27,8 +27,8 @@ ServerName localhost
     Deny from All
 </Directory>
 
-# Set server tokens (security??)
-ServerTokens Maj
+# Set server tokens
+ServerTokens OS
 
 # Now we include the generic VHOST configuration file that holds all the ZPanel user hosted vhost data
 Include /etc/zpanel/configs/apache/httpd-vhosts.conf


### PR DESCRIPTION
Across all OS config packs, the server tokens have been set to the lowest level which will allow ZPanel to detect what OS is running in the server information tab but won't share too many server details with the rest of the web.
