### PR TITLE
Denied access to module hook files

### DIFF
--- a/etc/build/config_packs/centos_6/apache/httpd.conf
+++ b/etc/build/config_packs/centos_6/apache/httpd.conf
@@ -24,6 +24,10 @@ Alias /zpanel /etc/zpanel/panel
     Order Deny,Allow
     Deny from All
 </Directory>
+<Directory /etc/zpanel/panel/modules/*/hooks>
+    Order Deny,Allow
+    Deny from All
+</Directory>
 
 # Set server tokens
 ServerTokens Prod

--- a/etc/build/config_packs/centos_6_2/apache/httpd.conf
+++ b/etc/build/config_packs/centos_6_2/apache/httpd.conf
@@ -23,6 +23,10 @@ Alias /zpanel /etc/zpanel/panel
     Order Deny,Allow
     Deny from All
 </Directory>
+<Directory /etc/zpanel/panel/modules/*/hooks>
+    Order Deny,Allow
+    Deny from All
+</Directory>
 
 # Set server tokens (security??)
 ServerTokens Maj

--- a/etc/build/config_packs/centos_6_3/apache/httpd.conf
+++ b/etc/build/config_packs/centos_6_3/apache/httpd.conf
@@ -24,6 +24,10 @@ Alias /zpanel /etc/zpanel/panel
     Order Deny,Allow
     Deny from All
 </Directory>
+<Directory /etc/zpanel/panel/modules/*/hooks>
+    Order Deny,Allow
+    Deny from All
+</Directory>
 
 # Set server tokens (security??)
 ServerTokens Major

--- a/etc/build/config_packs/ubuntu_12_04/apache/httpd.conf
+++ b/etc/build/config_packs/ubuntu_12_04/apache/httpd.conf
@@ -26,6 +26,10 @@ ServerName localhost
     Order Deny,Allow
     Deny from All
 </Directory>
+<Directory /etc/zpanel/panel/modules/*/hooks>
+    Order Deny,Allow
+    Deny from All
+</Directory>
 
 # Set server tokens (security??)
 ServerTokens Maj


### PR DESCRIPTION
As proposed by @5050 in #39 this now sits in the Sentora vhost file and blocks access to files in the hooks folder which shouldn't be executable from the web.
