### PR TITLE
Update generic.class.php

### DIFF
--- a/dryden/ws/generic.class.php
+++ b/dryden/ws/generic.class.php
@@ -79,16 +79,18 @@ class ws_generic {
 
     /**
      * Returns the value of a tag from an XML string.
-     * @author Bobby Allen (ballen@bobbyallen.me)
+     * Note: this should function should be written to use xpath instead of these build methods. As groupings may have unintended results.
+     * 
+     * @author Bobby Allen (ballen@bobbyallen.me) && Lloyd Leung (ll@lloydleung.com)
      * @param string $tagname The name of the tag of which to retrieve the value from.
      * @param string $xml The XML string
-     * @return string The XML tag value. 
+     * @return null|string The XML tag value, or null if not found.
      */
     static function GetTagValue($tagname, $xml) {
-        $matches = array();
         $pattern = "/<$tagname>(.*?)<\/$tagname>/";
         preg_match($pattern, $xml, $matches);
-        return $matches[1];
+
+        return isset($matches[1]) ? $matches[1] : null;
     }
 
     /**
@@ -212,5 +214,3 @@ class ws_generic {
     }
 
 }
-
-?>


### PR DESCRIPTION
Fixed a bug, when using GetTagValue(), and specifying an element that does not exist, the function would  would return a warning:
Notice: Undefined offset: 1 in /etc/zpanel/panel/dryden/ws/generic.class.php

$matches does not initialized first when being passed into preg_match.
trinary used for return statement.  If found, return it, else null.
Removed redundant php close tag.
