### PR TITLE
Ignore Deleted Accounts in Email Unique Check

### DIFF
--- a/dryden/ctrl/users.class.php
+++ b/dryden/ctrl/users.class.php
@@ -203,7 +203,7 @@ class ctrl_users {
      */
     static function CheckUserEmailIsUnique($email) {
         global $zdbh;
-            $sql = "SELECT COUNT(*) FROM x_accounts WHERE LOWER(ac_email_vc)=:email";
+            $sql = "SELECT COUNT(*) FROM x_accounts WHERE ac_deleted_ts IS NULL AND LOWER(ac_email_vc)=:email";
             $uniqueuser = $zdbh->prepare($sql);
             $uniqueuser->bindParam(':email', $email);
             if ($uniqueuser->execute()) {


### PR DESCRIPTION
At present, an email address assigned to a deleted account is not able to be used should they re-sign up, as it already exists on an account despite being deleted. Updating the CheckUserEmailIsUnique function to not count email addresses from deleted accounts, as these email addresses may be used when a new account is established for the customer.

Alternatively, an option could be included to reactivate a deleted account, but I don't this would be a preferred option.

Happy to receive feedback on this