### PR TITLE
Made FTP accounts start with username prefix.

### DIFF
--- a/modules/ftp_management/code/controller.ext.php
+++ b/modules/ftp_management/code/controller.ext.php
@@ -185,6 +185,7 @@ class module_controller extends ctrl_module
             }
             $sql = $zdbh->prepare("INSERT INTO x_ftpaccounts (ft_acc_fk, ft_user_vc, ft_directory_vc, ft_access_vc, ft_password_vc, ft_created_ts) VALUES (:userid, :username, :homedir, :accesstype, :password, :time)");
             $sql->bindParam(':userid', $currentuser['userid']);
+            $username = $currentuser['username'] . '_' . $username;
             $sql->bindParam(':username', $username);
             $sql->bindParam(':homedir', $homedirectory_to_use);
             $sql->bindParam(':accesstype', $access_type);

--- a/modules/ftp_management/module.zpm
+++ b/modules/ftp_management/module.zpm
@@ -109,7 +109,7 @@
                         <table class="table table-striped">
                             <tr>
                                 <th nowrap="nowrap"><: Username :>:</th>
-                                <td><input name="inFTPUsername" type="text" id="inFTPUsername" size="30" value="" maxlength="50"/></td>
+                                <td><em><# ui_tpl_username #></em>_<input name="inFTPUsername" type="text" id="inFTPUsername" size="30" value="" maxlength="50"/></td>
                             </tr>
                             <tr>
                                 <th><: Password :>:</th>


### PR DESCRIPTION
I've changed the FTP Management module to let FTP accounts have the username as prefix.

Example: zadmin_username, reseller_username, client_username
![image](https://cloud.githubusercontent.com/assets/6236059/8026427/56fc3c48-0d75-11e5-814c-07920eb7c90a.png)

Request thread on Sentora Forums: http://forums.sentora.org/showthread.php?tid=1579
