### PR TITLE
Template custom service status icons

### DIFF
--- a/modules/services/code/controller.ext.php
+++ b/modules/services/code/controller.ext.php
@@ -40,8 +40,11 @@ class module_controller extends ctrl_module
     static public function getServices()
     {
         global $controller;
-        $iconpath = '<img src="modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/';
-        
+        if(file_exists(ui_tpl_assetfolderpath::Template() . 'img/modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/up.gif') && file_exists(ui_tpl_assetfolderpath::Template() . 'img/modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/down.gif')) {
+            $iconpath = '<img src="' . ui_tpl_assetfolderpath::Template() . 'img/modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/';
+        }else{
+            $iconpath = '<img src="modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/';    
+        }
         $line = "<h2>" . ui_language::translate("Checking status of services...") . "</h2>";
         $line .= "<table>";
         


### PR DESCRIPTION
I've added the functionality for templates to use custom icons at the services module. When icon is not found at template folder, regular icon will be used.