### PR TITLE
Update apache Virtual Host for support Apache 2.4.x ~ 2.4.12, Require all granted

### DIFF
--- a/modules/apache_admin/hooks/OnDaemonRun.hook.php
+++ b/modules/apache_admin/hooks/OnDaemonRun.hook.php
@@ -185,8 +185,13 @@ function WriteVhostConfigFile()
                 $line .= '<Directory "' . ctrl_options::GetSystemOption('static_dir') . 'diskexceeded">' . fs_filehandler::NewLine();
                 $line .= "  Options +FollowSymLinks -Indexes" . fs_filehandler::NewLine();
                 $line .= "  AllowOverride All" . fs_filehandler::NewLine();
-                $line .= "  Order Allow,Deny" . fs_filehandler::NewLine();
-                $line .= "  Allow from all" . fs_filehandler::NewLine();
+	    if ((double) sys_versions::ShowApacheVersion() < 2.4) {
+		$line .= "    Order allow,deny" . fs_filehandler::NewLine();
+		$line .= "    Allow from all" . fs_filehandler::NewLine();
+	    } else {
+		$line .= "    Require all granted" . fs_filehandler::NewLine();
+	    }
+
                 $line .= "</Directory>" . fs_filehandler::NewLine();
                 $line .= ctrl_options::GetSystemOption('php_handler') . fs_filehandler::NewLine();
                 $line .= ctrl_options::GetSystemOption('dir_index') . fs_filehandler::NewLine();
@@ -218,8 +223,13 @@ function WriteVhostConfigFile()
                 $line .= '<Directory "' . ctrl_options::GetSystemOption('static_dir') . 'bandwidthexceeded">' . fs_filehandler::NewLine();
                 $line .= "  Options +FollowSymLinks -Indexes" . fs_filehandler::NewLine();
                 $line .= "  AllowOverride All" . fs_filehandler::NewLine();
-                $line .= "  Order Allow,Deny" . fs_filehandler::NewLine();
-                $line .= "  Allow from all" . fs_filehandler::NewLine();
+	    if ((double) sys_versions::ShowApacheVersion() < 2.4) {
+		$line .= "    Order allow,deny" . fs_filehandler::NewLine();
+		$line .= "    Allow from all" . fs_filehandler::NewLine();
+	    } else {
+		$line .= "    Require all granted" . fs_filehandler::NewLine();
+	    }
+
                 $line .= "</Directory>" . fs_filehandler::NewLine();
                 $line .= ctrl_options::GetSystemOption('php_handler') . fs_filehandler::NewLine();
                 $line .= ctrl_options::GetSystemOption('dir_index') . fs_filehandler::NewLine();
@@ -250,8 +260,13 @@ function WriteVhostConfigFile()
                 $line .= '<Directory "' . ctrl_options::GetSystemOption('parking_path') . '">' . fs_filehandler::NewLine();
                 $line .= "  Options +FollowSymLinks -Indexes" . fs_filehandler::NewLine();
                 $line .= "  AllowOverride All" . fs_filehandler::NewLine();
-                $line .= "  Order Allow,Deny" . fs_filehandler::NewLine();
-                $line .= "  Allow from all" . fs_filehandler::NewLine();
+	    if ((double) sys_versions::ShowApacheVersion() < 2.4) {
+		$line .= "    Order allow,deny" . fs_filehandler::NewLine();
+		$line .= "    Allow from all" . fs_filehandler::NewLine();
+	    } else {
+		$line .= "    Require all granted" . fs_filehandler::NewLine();
+	    }
+
                 $line .= "</Directory>" . fs_filehandler::NewLine();
                 $line .= ctrl_options::GetSystemOption('php_handler') . fs_filehandler::NewLine();
                 $line .= ctrl_options::GetSystemOption('dir_index') . fs_filehandler::NewLine();
@@ -318,8 +333,12 @@ function WriteVhostConfigFile()
                 $line .= '<Directory ' . $RootDir . '>' . fs_filehandler::NewLine();
                 $line .= "  Options +FollowSymLinks -Indexes" . fs_filehandler::NewLine();
                 $line .= "  AllowOverride All" . fs_filehandler::NewLine();
-                $line .= "  Order Allow,Deny" . fs_filehandler::NewLine();
-                $line .= "  Allow from all" . fs_filehandler::NewLine();
+	    if ((double) sys_versions::ShowApacheVersion() < 2.4) {
+		$line .= "    Order allow,deny" . fs_filehandler::NewLine();
+		$line .= "    Allow from all" . fs_filehandler::NewLine();
+	    } else {
+		$line .= "    Require all granted" . fs_filehandler::NewLine();
+	    }
                 $line .= "</Directory>" . fs_filehandler::NewLine();
 
                 // Enable Gzip until we set this as an option , we might commenbt this too and allow manual switch
@@ -398,8 +417,12 @@ function WriteVhostConfigFile()
             $line .= '<Directory "' . ctrl_options::GetSystemOption('static_dir') . 'disabled">' . fs_filehandler::NewLine();
             $line .= "  Options +FollowSymLinks -Indexes" . fs_filehandler::NewLine();
             $line .= "  AllowOverride All" . fs_filehandler::NewLine();
-            $line .= "  Order Allow,Deny" . fs_filehandler::NewLine();
-            $line .= "  Allow from all" . fs_filehandler::NewLine();
+	    if ((double) sys_versions::ShowApacheVersion() < 2.4) {
+		$line .= "    Order allow,deny" . fs_filehandler::NewLine();
+		$line .= "    Allow from all" . fs_filehandler::NewLine();
+	    } else {
+		$line .= "    Require all granted" . fs_filehandler::NewLine();
+	    }
             $line .= "</Directory>" . fs_filehandler::NewLine();
             $line .= ctrl_options::GetSystemOption('dir_index') . fs_filehandler::NewLine();
             $line .= "</virtualhost>" . fs_filehandler::NewLine();


### PR DESCRIPTION
The access control configuration changed in 2.4, and old configurations aren't compatible without some changes.
The old config was Allow from all (no IP addresses blocked from accessing the service), then Require all granted is the new functional equivilent.