### PR TITLE
Make Create a new task (Cron module)  translatable

### DIFF
--- a/modules/cron/code/controller.ext.php
+++ b/modules/cron/code/controller.ext.php
@@ -89,7 +89,7 @@ class module_controller extends ctrl_module
         global $controller;
         $currentuser = ctrl_users::GetUserDetail();
 
-        $line = "<h2>Create a new task</h2>";
+         $line .= "<h2>" . ui_language::translate("Create a new task") . "</h2>";
         $line .= "<form action=\"./?module=cron&action=CreateCron\" method=\"post\">";
         $line .= "<table class=\"table table-striped\">";
         $line .= "<tr valign=\"top\">";


### PR DESCRIPTION
Forgot to add ::translate

Why is there so many hardcoded?
