### PR TITLE
Enforcing MySQL username to max. 32

### DIFF
--- a/modules/mysql_users/code/controller.ext.php
+++ b/modules/mysql_users/code/controller.ext.php
@@ -520,7 +520,7 @@ class module_controller extends ctrl_module
         if (!preg_match('/^[a-z\d_][a-z\d_-]{0,62}$/i', $username) || preg_match('/-$/', $username)) {
             return false;
         } else {
-            if (strlen($username) < 17) {
+            if (strlen($username) < 32) {
                 // Enforce the MySQL username limit! (http://dev.mysql.com/doc/refman/4.1/en/user-names.html)
                 return true;
             }


### PR DESCRIPTION
Is it still neccesary to limit the MySQL username to max 17?
If not we can increase to 32.

If it does than we need to take in account that a sentora username is aso limited to lets say 8 or 10 chars, otherwise clients with longer usernames get problems creating mysql users.

See issue : https://github.com/sentora/sentora-core/issues/225