### PR TITLE
Cron Sending Mails to www-data

### DIFF
--- a/modules/cron/code/controller.ext.php
+++ b/modules/cron/code/controller.ext.php
@@ -262,7 +262,7 @@ class module_controller extends ctrl_module
         $line .= "# NEVER MANUALLY REMOVE OR EDIT ANY OF THE CRON ENTRIES FROM THIS FILE,          " . fs_filehandler::NewLine();
         $line .= "#  -> USE SENTORA INSTEAD! (Menu -> Advanced -> Cron Manager)                    " . fs_filehandler::NewLine();
         $line .= "#################################################################################" . fs_filehandler::NewLine();
-
+        $line .= "MAILTO=\"\"" . fs_filehandler::NewLine();
         //Write command lines in crontab, if any
         if ($numrows->fetchColumn() <> 0) {
             $sql = $zdbh->prepare($sql);


### PR DESCRIPTION
Cron sends mails to www-data every time that it finishes a scheduled task.
I fix the problem adding

```
$line .= "MAILTO=\"\"" . fs_filehandler::NewLine();
```

in line number 265.
Sorry my bad english level.
