### PR TITLE
Using better regex for emails

### DIFF
--- a/modules/manage_clients/code/controller.ext.php
+++ b/modules/manage_clients/code/controller.ext.php
@@ -683,7 +683,7 @@ class module_controller extends ctrl_module
 
     static function IsValidEmail($email)
     {
-        if (!preg_match('/^[a-z0-9]+([_\\.-][a-z0-9]+)*@([a-z0-9]+([\.-][a-z0-9]+)*)+\\.[a-z]{2,}$/i', $email)) {
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             return false;
         }
         return true;


### PR DESCRIPTION
The easiest and safest way to check whether an email address is well-formed is to use PHP's filter_var() function.
