### PR TITLE
Ignore deleted users for CheckEmailIsUnique and CheckUserExists

### DIFF
--- a/dryden/ctrl/users.class.php
+++ b/dryden/ctrl/users.class.php
@@ -203,7 +203,7 @@ class ctrl_users {
      */
     static function CheckUserEmailIsUnique($email) {
         global $zdbh;
-            $sql = "SELECT COUNT(*) FROM x_accounts WHERE LOWER(ac_email_vc)=:email";
+            $sql = "SELECT COUNT(*) FROM x_accounts WHERE LOWER(ac_email_vc)=LOWER(:email) AND ac_deleted_ts IS NULL";
             $uniqueuser = $zdbh->prepare($sql);
             $uniqueuser->bindParam(':email', $email);
             if ($uniqueuser->execute()) {

--- a/modules/manage_clients/code/controller.ext.php
+++ b/modules/manage_clients/code/controller.ext.php
@@ -723,7 +723,7 @@ class module_controller extends ctrl_module
     static function CheckUserExists($username)
     {
         global $zdbh;
-        $sql = "SELECT COUNT(*) FROM x_accounts WHERE LOWER(ac_user_vc)=:username";
+        $sql = "SELECT COUNT(*) FROM x_accounts WHERE LOWER(ac_user_vc)=:username AND ac_deleted_ts IS NULL";
         $uniqueuser = $zdbh->prepare($sql);
         $uniqueuser->bindParam(':username', strtolower($username));
         if ($uniqueuser->execute()) {


### PR DESCRIPTION
So after reworking the old WHMCS module I’ve noticed that the behaviour of CheckUserExists method in the manage_clients module and the ctrl_users::CheckEmailIsUnique is, in my opinion, somewhat unexpected.

They do count deleted accounts towards the lack of uniqueness in usernames and email addresses while the MySQL queries for username (GitHub Search for “ac_user_vc”) and email (GitHub Search for “ac_email_vc”) are always (at least the instances that I could find) accompanied by userid or a check that ac_deleted_ts IS NULL, with the exception being queries regarding the zadmin user of the panel.

Seeing as this causes issues when trying to add users manually or via the API, usernames and emails of accounts which are “deleted” can still not be used by new ones and the “deleted” account would have to manually be deleted from the MySQL table. I’m curious as to why and/or if this is the intended behaviour of the functions.

Bottom line, what are your thoughts on changing the previously mentioned methods to only count the accounts which haven’t been deleted towards the lack of uniqueness of a username/email?

(Also took the liberty of making the email check guaranteed to be case insensitive)