### PR TITLE
Fixes #207

### DIFF
--- a/modules/manage_clients/code/webservice.ext.php
+++ b/modules/manage_clients/code/webservice.ext.php
@@ -18,7 +18,7 @@ class webservice extends ws_xmws
     {
         $request_data = $this->RawXMWSToArray($this->wsdata);
         $contenttags = $this->XMLDataToArray($request_data['content']);
-        module_controller::ExecuteDeleteClient($contenttags['uid']);
+        module_controller::ExecuteDeleteClient($contenttags['uid'], $contenttags['moveid']);
         $dataobject = new runtime_dataobject();
         $dataobject->addItemValue('response', '');
         $dataobject->addItemValue('content', ws_xmws::NewXMLTag('uid', $contenttags['uid']) . ws_xmws::NewXMLTag('deleted', 'true'));

--- a/modules/manage_clients/code/webservice.ext.php
+++ b/modules/manage_clients/code/webservice.ext.php
@@ -18,7 +18,7 @@ class webservice extends ws_xmws
     {
         $request_data = $this->RawXMWSToArray($this->wsdata);
         $contenttags = $this->XMLDataToArray($request_data['content']);
-        module_controller::ExecuteDeleteClient($contenttags['uid'], $contenttags['moveid']);
+        module_controller::ExecuteDeleteClient($contenttags['uid'], empty($contenttags['moveid']) ? 1 : $contenttags['moveid']);
         $dataobject = new runtime_dataobject();
         $dataobject->addItemValue('response', '');
         $dataobject->addItemValue('content', ws_xmws::NewXMLTag('uid', $contenttags['uid']) . ws_xmws::NewXMLTag('deleted', 'true'));


### PR DESCRIPTION
Fixes error when calling manage_clients DeleteClient over API: `missing parameter in modules/manage_clients/code/webservice.ext.php::DeleteClient()`
