### PR TITLE
SQL Errors with time() and date()

### DIFF
--- a/dryden/debug/logger.class.php
+++ b/dryden/debug/logger.class.php
@@ -69,7 +69,7 @@ class debug_logger {
                 $retval = false;
             }
             try {
-                $statement = "INSERT INTO x_logs (lg_user_fk, lg_code_vc, lg_module_vc, lg_detail_tx, lg_stack_tx, lg_when_ts) VALUES (0, '" . $this->logcode . "', 'NA', '" . $this->detail . "', '" . $this->mextra . "','" . time() . "')";
+                $statement = "INSERT INTO x_logs (lg_user_fk, lg_code_vc, lg_module_vc, lg_detail_tx, lg_stack_tx, lg_when_ts) VALUES (0, '" . $this->logcode . "', 'NA', '" . $this->detail . "', '" . $this->mextra . "','" . date("Y-m-d H:i:s") . "')";
                 if ($zdbh->exec($statement) > 0) {
                     $retval = true;
                 } else {

--- a/modules/ftp_management/code/proftpd-mysql.php
+++ b/modules/ftp_management/code/proftpd-mysql.php
@@ -42,7 +42,7 @@ if (!fs_director::CheckForEmptyValue(self::$create)) {
     $sql = $ftp_db->prepare("INSERT INTO ftpquotalimits (name, quota_type, per_session, limit_type, bytes_in_avail, bytes_out_avail, bytes_xfer_avail, files_in_avail, files_out_avail, files_xfer_avail) VALUES (:username, 'user', 'true', 'hard', 0, 0, 0, 0, 0, 0);");
     $sql->bindParam(':username', $username);
     $sql->execute();
-    $sql = $ftp_db->prepare("INSERT INTO ftpuser (id, userid, passwd, homedir, shell, count, accessed, modified) VALUES ('', :username, :password, :homedir, '/sbin/nologin', 0, '', '');");
+    $sql = $ftp_db->prepare("INSERT INTO ftpuser (userid, passwd, homedir, shell, count, accessed, modified) VALUES (:username, :password, :homedir, '/sbin/nologin', 0, '" . date("Y-m-d H:i:s") ."', '" . date("Y-m-d H:i:s") . "');");
     $sql->bindParam(':username', $username);
     $sql->bindParam(':password', $password);
     $sql->bindParam(':homedir', $homedir);

--- a/modules/ftp_management/code/proftpd.php
+++ b/modules/ftp_management/code/proftpd.php
@@ -42,7 +42,7 @@ if (!fs_director::CheckForEmptyValue(self::$create)) {
     $sql = $ftp_db->prepare("INSERT INTO ftpquotalimits (name, quota_type, per_session, limit_type, bytes_in_avail, bytes_out_avail, bytes_xfer_avail, files_in_avail, files_out_avail, files_xfer_avail) VALUES (:username, 'user', 'true', 'hard', 0, 0, 0, 0, 0, 0);");
     $sql->bindParam(':username', $username);
     $sql->execute();
-    $sql = $ftp_db->prepare("INSERT INTO ftpuser (id, userid, passwd, homedir, shell, count, accessed, modified) VALUES ('', :username, :password, :homedir, '/sbin/nologin', 0, '', '');");
+    $sql = $ftp_db->prepare("INSERT INTO ftpuser (userid, passwd, homedir, shell, count, accessed, modified) VALUES (:username, :password, :homedir, '/sbin/nologin', 0, '" . date("Y-m-d H:i:s") ."', '" . date("Y-m-d H:i:s") . "');");
     $sql->bindParam(':username', $username);
     $sql->bindParam(':password', $password);
     $sql->bindParam(':homedir', $homedir);


### PR DESCRIPTION
This is better for some mysql-Versions and Bridges as time() will fail at SQL-reverse (it gets inserted right but state is always false). We prevent this by formatting it into the preferred format with date()
