### PR TITLE
Use HTTPS only with Gravatar images

### DIFF
--- a/dryden/ui/tpl/modulelistznavbar.class.php
+++ b/dryden/ui/tpl/modulelistznavbar.class.php
@@ -112,7 +112,7 @@ class ui_tpl_modulelistznavbar
      */
     public static function get_gravatar($email, $s = 80, $d = 'mm', $r = 'g', $img = false, $atts = array())
     {
-        $url = self::getCurrentProtocol() . 'www.gravatar.com/avatar/';
+        $url = 'https://www.gravatar.com/avatar/';
         $url .= md5(strtolower(trim($email)));
         $url .= "?s=$s&d=$d&r=$r";
         if ($img) {


### PR DESCRIPTION
Works better for sites behind for example CloudFlare. Even though HTTP is used, HTTPS should be used for as much as possible 👍 