### PR TITLE
make stats incremental, preserve days

### DIFF
--- a/modules/webalizer_stats/hooks/OnDaemonHour.hook.php
+++ b/modules/webalizer_stats/hooks/OnDaemonHour.hook.php
@@ -42,7 +42,7 @@ function GenerateWebalizerStats()
         /** all other args and flags are the same so keep them outsite to avoid duplication */
         $flag        = '-o';
         
-        $secondFlags = '-d -F clf -n';
+        $secondFlags = '-d -p -F clf -n';
 
         $domain = $rowvhost[ 'vh_name_vc' ];
 


### PR DESCRIPTION
I've added the -p flag (increment) to webalizer call so all the days of the month get showed in the stats, previously the webalizer was buggy, only the days found in the active log (before rotation) were showed. E.G. for each month only the 31st or 30th of the month were available.