### PR TITLE
Fix MySQL GRANT statement parameter binding bug (Fixes #410)

### DIFF
--- a/modules/mysql_users/code/controller.ext.php
+++ b/modules/mysql_users/code/controller.ext.php
@@ -436,13 +436,11 @@ class module_controller extends ctrl_module
         $my_name_vc = $zdbh->mysqlRealEscapeString($rowdb['my_name_vc']);
         $mu_name_vc = $zdbh->mysqlRealEscapeString($rowuser['mu_name_vc']);
         $mu_access_vc = $zdbh->mysqlRealEscapeString($rowuser['mu_access_vc']);
-        $sql = $zdbh->prepare("GRANT ALL PRIVILEGES ON `$my_name_vc`.* TO `$mu_name_vc`@`$mu_access_vc`");
-        $sql->bindParam(':my_name_vc', $rowdb['my_name_vc'], PDO::PARAM_STR);
-        $sql->bindParam(':mu_name_vc', $rowuser['mu_name_vc'], PDO::PARAM_STR);
-        $sql->bindParam(':mu_access_vc', $rowuser['mu_access_vc'], PDO::PARAM_STR);
-        $sql->execute();
-        $sql = $zdbh->prepare("FLUSH PRIVILEGES");
-        $sql->execute();
+        // GRANT statement - cannot use parameter binding for database/user names
+        // MySQL GRANT statements don't support placeholders for database, user, or host names
+        $grant_sql = "GRANT ALL PRIVILEGES ON `$my_name_vc`.* TO `$mu_name_vc`@`$mu_access_vc`";
+        $zdbh->exec($grant_sql);
+        $zdbh->exec("FLUSH PRIVILEGES");
         $sql2 = $zdbh->prepare("
 			INSERT INTO x_mysql_dbmap (
 							mm_acc_fk,


### PR DESCRIPTION
```markdown
## Description
Fixes the bug where assigning databases to MySQL users (or vice versa) results in a blank page in Sentora 2.1.0 BETA.

## Problem
The `ExecuteAddDB()` function in `mysql_users` module was attempting to use `bindParam()` with parameters that don't exist in the SQL query string. MySQL GRANT statements don't support parameter placeholders for database names, usernames, or hostnames. PHP 8.3 is stricter about parameter binding mismatches, causing a silent failure.

## Solution
- Removed incorrect `bindParam()` calls for GRANT statement
- Changed from `prepare()` + `bindParam()` + `execute()` to `exec()` directly
- Added comment explaining why parameter binding cannot be used
- Values are already properly escaped using `mysqlRealEscapeString()`

## Testing
- ✅ Tested on Ubuntu 24.04 LTS
- ✅ Tested with PHP 8.3.6
- ✅ Successfully assigns databases to users
- ✅ Successfully assigns users to databases
- ✅ No syntax errors
- ✅ Manual MySQL operations verified

## Related Issue
Fixes #410

## Files Changed
- `modules/mysql_users/code/controller.ext.php` (ExecuteAddDB function)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL database user privilege assignment to ensure permissions are correctly applied when creating new database users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->